### PR TITLE
Prevent overwriting of transformed file when using build acceleration

### DIFF
--- a/FastBuildTransform/FastBuildTransform.csproj
+++ b/FastBuildTransform/FastBuildTransform.csproj
@@ -11,7 +11,7 @@
     <None Include="NLog.config">
       <SubType>Designer</SubType>
       <TransformOnBuild>true</TransformOnBuild>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="NLog.Debug.config">
       <IsTransformFile>True</IsTransformFile>


### PR DESCRIPTION
This is the change required to prevent builds from overwriting the transformed file when the project is accelerated.

See https://github.com/dotnet/project-system/issues/8886#issuecomment-1449484244 for further details.